### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,15 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      secrets: read
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
@@ -70,6 +76,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: test
     
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/hooperits/hooperits-ai-agent-cli/security/code-scanning/2](https://github.com/hooperits/hooperits-ai-agent-cli/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Since the workflow involves actions like checking out code, caching dependencies, running tests, and uploading artifacts, the `contents: read` permission is sufficient for most steps. For the `test` job, which uses a secret (`GOOGLE_API_KEY`), we should ensure that the secret is accessible. For the `build` job, no additional permissions beyond `contents: read` are required.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within each job to specify permissions individually.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
